### PR TITLE
Print hitlist to txt feature

### DIFF
--- a/Crawler.java
+++ b/Crawler.java
@@ -10,6 +10,8 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.apache.commons.validator.routines.UrlValidator;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 public class Crawler{
@@ -191,7 +193,9 @@ public class Crawler{
 
   }
 
-  public static HashSet<URL> crawl(String seed_Url, String keyToFind) throws MalformedURLException{
+  // Overloaded Method for exhaustive crawl
+
+  public static HashSet<URL> crawl(String seed_Url, String keyToFind, String pathToTxtFile) throws MalformedURLException{
 
 	    // We will return a list of URLs corresponding to "hits" to investigate.
 
@@ -364,15 +368,59 @@ public class Crawler{
 
 	    }
 
+
 	    System.out.println("Total of:  " + pageCount + " pages." + "\nHome URL:  " + seed_Url);
+
+	    try{
+	    	writeHitList(sitesWith_Key, pathToTxtFile);
+	    } catch(IOException ex){
+	    	ex.printStackTrace();
+	    }
+
 
 	    return sitesWith_Key; // return our URL path.
 
 	  }
+
+  // Feature that enables a HashSet<E> to be passed as a parameter to write the "hitlist" to a new local .txt file
+
+  private static void writeHitList(HashSet<URL> myHitList, String fulltxtFilePath) throws IOException{
+
+
+	  File hit_txt_File = new File(fulltxtFilePath); // Does not actually create the new file, just corresponding object
+
+	  hit_txt_File.getParentFile().mkdirs();
+
+
+	  try{
+		  hit_txt_File.createNewFile(); // Creates the new File ONLY IF that file doesn't already exist.
+	  } catch (IOException ex){
+		  ex.printStackTrace();
+	  }
+
+
+	  FileWriter myWriter = new FileWriter(hit_txt_File); // Character writer object to write characters into a txt file
+
+	  Iterator<URL> iterator = myHitList.iterator();
+
+	  while(iterator.hasNext()){ // while the list has another value keep iterating
+		  try{
+			  myWriter.write(iterator.next() + "\n"); // write the hit link into the file.
+		  } catch(IOException ex){
+			  ex.printStackTrace();
+		  }
+	  }
+
+	  myWriter.close();
+
+
+  }
+
+
   public static void main(String[] args) throws MalformedURLException{
 
 
-	  HashSet<URL> pathTraveled = crawl("http://www.cnn.com/", "Trump");
+	  HashSet<URL> pathTraveled = crawl("http://www.cnn.com/", "Trump", "/Users/justinstuart/Desktop/Scraped_Data/cnn_TrumpArticles.txt");
 
 
 	  Iterator<URL> iterator = pathTraveled.iterator();

--- a/Crawler.java
+++ b/Crawler.java
@@ -76,7 +76,6 @@ public class Crawler{
     	   * us to parse a URL into a document for operationalization.
     	   */
     	  myDoc = Jsoup.connect(currentURL.toString()).get();
-          visitedSites.add(currentURL.toString());
 
       }catch (IOException ex){
     	  System.out.println("IO");
@@ -85,29 +84,37 @@ public class Crawler{
     	   * Note: We do NOT want to stop the program just because a certain URL can't be resolved.
     	   */
     	  continue;
+      } finally{
+          visitedSites.add(currentURL.toString());
       }
 
       // We now have an acceptable HTML document to parse via Jsoup connection
 
+      int linksPerPage = 10; // Limit of links to enqueue per page (so all links don't come from one page)
+
+
       Elements currentURL_Links = myDoc.select("a[href]");
 
       // Selects all address tags hrefs and stores in ArrayList<Element> extension --> Elements
+
+      if(currentURL_Links.isEmpty()) // If the Links page is empty, dequeue the next searchable link without further processing
+    	  continue;
 
 
       String regexToParseFor = ".*" + keyToFind.toLowerCase() + ".*"; // Stores the regex we will look into titles for
 
 
 
-      for(int i = 0; i < currentURL_Links.size(); i++){
+      for(int i = 0; i < linksPerPage; i++){
     	  /*
     	   * Iterate over each Element object and add them to the queue if they
     	   * fit our specifications.
     	   */
-    	  Element currentEle = currentURL_Links.get(i);
+    	  Element currentEle = currentURL_Links.get((int) ((Math.random() * (currentURL_Links.size()))));
 
     	  /*
-    	   * Retrieves the ith element (link) within our list of elements (links)
-    	   * Now we have a sole element (link) to work with. (href = "https://www.example.com")
+    	   * Use a Math.random for a value between 0 and 1 (exclusive), scale it by the size of the link list then cast to int.
+    	   * Ex: size = 10, we can get 0 if random() yields .01 --> 10*.01 --> .10, which is int casted to 0.
     	   */
 
     	  String link_Href = currentEle.attr("abs:href");
@@ -184,10 +191,188 @@ public class Crawler{
 
   }
 
+  public static HashSet<URL> crawl(String seed_Url, String keyToFind) throws MalformedURLException{
+
+	    // We will return a list of URLs corresponding to "hits" to investigate.
+
+
+		// Initialize data structures and variables to use
+
+	    ArrayDeque<URL> queueOf_SearchableURLs = new ArrayDeque<>(); // Initialize queue of URLs to search
+	    HashSet<String> visitedSites = new HashSet<>(); // Set to track our progress
+
+	    HashSet<URL> sitesWith_Key = new HashSet<>(); // Will track sites with a given key found
+
+	    int pageCount = 0;
+
+
+	    String[] schemes = {"http", "https"}; // We will be looking at only http and https protocols as our seed
+
+	    UrlValidator urlValidatorObj = new UrlValidator(schemes);
+
+	    /*
+	     * Validator made to be predisposed to protocols: HTTP and HTTPS
+	     */
+
+	    if(!urlValidatorObj.isValid(seed_Url)){ // If the URL is invalid, we will stop before we begin.
+	      System.out.println("Seed URL is invalid");
+	      pageCount++;
+	      return null;
+	    }
+
+	    // If we are at this point, we know the seed_Url is valid.
+	    try{
+	    	System.out.println("Seed URL is valid.");
+	    	queueOf_SearchableURLs.add(new URL(seed_Url)); // Add the validated seed URL to the queue.
+	    }catch (MalformedURLException ex){
+
+	    	ex.printStackTrace();
+	    }
+
+
+
+	    while(!queueOf_SearchableURLs.isEmpty()){
+
+	      // while the pending URL queue is NOT empty AND we haven't reached the limit of pages to parse.
+
+	      URL currentURL = queueOf_SearchableURLs.remove();
+
+
+	      // currentURL is the URL previously at head of the queue.
+
+
+
+	      // At this point, we KNOW we have a valid, unvisited URL in "currentURL"
+
+	      Document myDoc = null; // Solely declared for scoping purposes here.
+
+	      try{
+	    	  /*
+	    	   * Jsoup.parse(URL myURL, int millisToTimeOut) is a method in JSoup library that allows
+	    	   * us to parse a URL into a document for operationalization.
+	    	   */
+	    	  myDoc = Jsoup.connect(currentURL.toString()).get();
+
+	      }catch (IOException ex){
+	    	  System.out.println("IO");
+	    	  /*
+	    	   * Promptly note the IO exception in console and continue
+	    	   * Note: We do NOT want to stop the program just because a certain URL can't be resolved.
+	    	   */
+	    	  continue;
+	      } finally{
+	          visitedSites.add(currentURL.toString()); // add the URL to visitedSites so we do not visit it again later.
+	          pageCount++; // Track pages
+	      }
+
+	      // We now have an acceptable HTML document to parse via Jsoup connection
+
+	      int linksPerPage = 10; // Limit of links to enqueue per page (so all links don't come from one page)
+
+
+	      Elements currentURL_Links = myDoc.select("a[href]");
+
+	      // Selects all address tags hrefs and stores in ArrayList<Element> extension --> Elements
+
+	      if(currentURL_Links.isEmpty()) // If the Links page is empty, dequeue the next searchable link without further processing
+	    	  continue;
+
+
+	      String regexToParseFor = ".*" + keyToFind.toLowerCase() + ".*"; // Stores the regex we will look into titles for
+
+
+
+	      for(int i = 0; i < currentURL_Links.size(); i++){
+	    	  /*
+	    	   * Iterate over each Element object and add them to the queue if they
+	    	   * fit our specifications.
+	    	   */
+	    	  Element currentEle = currentURL_Links.get(i);
+
+	    	  /*
+	    	   * Use a Math.random for a value between 0 and 1 (exclusive), scale it by the size of the link list then cast to int.
+	    	   * Ex: size = 10, we can get 0 if random() yields .01 --> 10*.01 --> .10, which is int casted to 0.
+	    	   */
+
+	    	  String link_Href = currentEle.attr("abs:href");
+
+	    	  /*
+	    	   * Node.attr(String key) method returns the value of the attribute matching our key
+	    	   * In this case, it's href because we want a String representation of the actual link value.
+	    	   */
+
+
+
+	    	  /*
+	    	   * To circumvent the issue of MalformedURLExceptions, utilize a boolean variable
+	    	   * and if a MalformedURLException occurs, simply continue, causing the algorithm to pop the
+	    	   * next URL and proceed.
+	    	   */
+
+	    	  boolean queueContainsLink = true;
+
+	    	  try{
+	    		  queueContainsLink = queueOf_SearchableURLs.contains(new URL(link_Href));
+	    	  }catch(MalformedURLException ex){
+	    		  continue;
+	    	  }
+
+
+	    	  if(!queueContainsLink && !visitedSites.contains(link_Href)){
+	    		  /*
+	    		   * If BOTH our Pending URL queue AND VisitedSite Set do NOT contain the link
+	    		   * AND we haven't reached our limit of links.
+	    		   */
+
+	    		  if(link_Href.contains("#") || !(urlValidatorObj.isValid(link_Href))){
+	    			  /*
+	    			   * If the link contains a pound sign OR it is deemed invalid by our
+	    			   * Http and Https URL validator, re-loop WITHOUT adding anything to the
+	    			   * search queue.
+	    			   *
+	    			   */
+
+	    			  continue;
+	    		  }
+
+	    		  if(!link_Href.contains(seed_Url)) // If our link has left the home site, restart process with next link
+	    			  continue;
+
+
+	    		  if(link_Href.matches(regexToParseFor))
+	    			  sitesWith_Key.add(new URL(link_Href));
+	    		  /*
+	    		   *  If our link matches our user-given string, add it to the Set to return
+	    		   *  for further investigation.
+	    		   */
+
+	    		  queueOf_SearchableURLs.add(new URL(link_Href));
+
+	    		  /*
+	    		   * Regardless of whether or not it matches our regex, add it to searchable queue of URLs
+	    		   * to keep crawling for more regex hits.
+	    		   */
+
+	    	  } else continue;
+
+
+	      }
+
+
+	      System.out.println("Just visited: " + currentURL.toString() +  "\nSize of Path: " + visitedSites.size());
+	      // Test code.
+
+	    }
+
+	    System.out.println("Total of:  " + pageCount + " pages." + "\nHome URL:  " + seed_Url);
+
+	    return sitesWith_Key; // return our URL path.
+
+	  }
   public static void main(String[] args) throws MalformedURLException{
 
 
-	  HashSet<URL> pathTraveled = crawl("http://www.cnn.com/", 300, "Trump");
+	  HashSet<URL> pathTraveled = crawl("http://www.cnn.com/", "Trump");
 
 
 	  Iterator<URL> iterator = pathTraveled.iterator();

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crawler for User Keywords
+# Project1
 
 Primary Goal:
 
@@ -14,11 +14,9 @@ Primary Goal:
 
 - If Crawler throws a MalformedURLException or a IOException, it will stop operations on the current URL and will pop off the next URL to be operationalized.
 
-- Crawler will return a set of sites that match a user specification.
-
 
 Desirable Feature(s) (To be implemented later):
 
-- Tag sites with links that mentioned a specific user-given String (Done)
+- Tag sites that have mentioned a specific user-given String.
 
-- Restrict crawler to one main domain site (Done)
+- Implement an exhaustive crawl, to continue crawling until the queue of links to be searched. It is accessed by using an overloaded static crawl method. (where seed_Url and keyString is provided with no page limit)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Primary Goal:
 
 Desirable Feature(s) (To be implemented later):
 
-- Tag sites that have mentioned a specific user-given String.
+- Tag sites that have mentioned a specific user-given String. (Done)
 
-- Implement an exhaustive crawl, to continue crawling until the queue of links to be searched. It is accessed by using an overloaded static crawl method. (where seed_Url and keyString is provided with no page limit)
+- Implement an exhaustive crawl, to continue crawling until the queue of links to be searched. It is accessed by using an overloaded static crawl method. (Done)
+
+- Have the crawler create and write the list of URLs into a txtFile, whose path is determined by a passed String parameter. (Done)


### PR DESCRIPTION
General:
- Uses finally clause to always add the current URL, whether an exception is thrown or not, to a set of visited sites

Limited Crawl Method
- Now, rather than taking all links from the first URL that's given, the algorithm will take a random 10 links from the page before continuing to the next URL.

Exhaustive Crawl Method
- Implemented Write to File Feature, where every link found under a user-given directory that involves a user-given keyword will be written to a newly created (or overwritten if the file already exists) txt file.

README
- Updates README in order to remain aligned with current functionality.
